### PR TITLE
Use generic paths for agent

### DIFF
--- a/templates/mitaka/opflex-agent-ovs.conf
+++ b/templates/mitaka/opflex-agent-ovs.conf
@@ -15,11 +15,11 @@
        },
        "inspector": {
            "enabled": true,
-           "socket-name": "/var/run/opflex-agent-ovs-inspect.sock"
+           "socket-name": "/var/run/opflex-agent-inspect.sock"
        },
        "notif": {
            "enabled": true,
-           "socket-name": "/var/run/opflex-agent-ovs-notif.sock",
+           "socket-name": "/var/run/opflex-agent-notif.sock",
            // "socket-owner": "root",
            "socket-group": "opflexep",
            "socket-permissions": "770"


### PR DESCRIPTION
The ganga release of the opflex-agent uses a more generic
path for the notify and inspect sockets.