### PR TITLE
Added transport_url to /etc/nova/nova.conf

### DIFF
--- a/templates/newton/nova.conf
+++ b/templates/newton/nova.conf
@@ -17,6 +17,9 @@ multi_host=True
 network_api_class=nova.network.neutronv2.api.API
 use_neutron = True
 metadata_workers = {{ workers }}
+{% if transport_url %}
+transport_url = {{ transport_url }}
+{% endif %}
 
 {% if vendor_data or vendor_data_url -%}
 [api]


### PR DESCRIPTION
The nova metadata service requires transport_url in ussuri.